### PR TITLE
Add workaround for CLJ-1466 allowing a map returned from (bean) to print

### DIFF
--- a/src/aprint/dispatch.clj
+++ b/src/aprint/dispatch.clj
@@ -41,6 +41,8 @@
 (defn- pprint-map-sorted [amap]
   (try
     (pprint-map (into (sorted-map) amap) true)
+    ;; workaround http://dev.clojure.org/jira/browse/CLJ-1466
+    (catch AbstractMethodError e (pprint-map (into (sorted-map) (seq amap)) true))
     (catch ClassCastException e (pprint-map amap false))))
 
 (defn- pprint-simple-list [alis]
@@ -71,4 +73,3 @@
 (use-method color-dispatch java.lang.String (partial color-pprint :yellow))
 (use-method color-dispatch nil pr)
 (use-method color-dispatch :default pprint/simple-dispatch)
-


### PR DESCRIPTION
Currently aprint will throw an AbstractMethodError if trying to pretty print a map returned from the bean function. This patch works around the issue.
